### PR TITLE
Add custom drink counter card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # ha-drink-counter-lovelace
+
+A simple Lovelace card for showing drink counts per user. Select a name and the card displays how many drinks of each type that user has consumed and the amount owed based on configurable prices.
+
+## Installation
+
+1. Copy `drink-counter-card.js` to your Home Assistant `www` directory.
+2. Add the following to your Lovelace resources:
+   ```yaml
+   - url: /local/drink-counter-card.js
+     type: module
+   ```
+
+## Example
+
+```yaml
+type: custom:drink-counter-card
+users:
+  - name: Alice
+    drinks:
+      beer: sensor.alice_beer
+      water: sensor.alice_water
+  - name: Bob
+    drinks:
+      beer: sensor.bob_beer
+      water: sensor.bob_water
+prices:
+  beer: 2.5
+  water: 1.0
+```
+
+This configuration creates a dropdown with *Alice* and *Bob*. The card uses the defined sensors to read drink counts and multiplies them by the given prices to show totals.
+

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -1,0 +1,83 @@
+import { LitElement, html, css } from 'https://unpkg.com/lit?module';
+
+class DrinkCounterCard extends LitElement {
+  static properties = {
+    hass: {},
+    config: {},
+    selectedUser: { state: true },
+  };
+
+  setConfig(config) {
+    if (!config.users || !Array.isArray(config.users)) {
+      throw new Error("The 'users' property is required and must be an array.");
+    }
+    if (!config.prices || typeof config.prices !== 'object') {
+      throw new Error("The 'prices' property is required and must be an object.");
+    }
+    this.config = config;
+    this.selectedUser = config.users[0]?.name;
+  }
+
+  get userData() {
+    if (!this.config) return null;
+    return this.config.users.find(u => u.name === this.selectedUser);
+  }
+
+  render() {
+    if (!this.hass || !this.config) return html``;
+    const user = this.userData;
+    if (!user) return html`<ha-card>Unknown user</ha-card>`;
+    const prices = this.config.prices;
+    let total = 0;
+    const rows = Object.entries(user.drinks).map(([drink, entity]) => {
+      const count = Number(this.hass.states[entity]?.state || 0);
+      const price = Number(prices[drink] || 0);
+      const cost = count * price;
+      total += cost;
+      return html`<tr><td>${drink}</td><td>${count}</td><td>${price}</td><td>${cost.toFixed(2)}</td></tr>`;
+    });
+
+    return html`
+      <ha-card>
+        <div class="user-select">
+          <label for="user">Name:</label>
+          <select id="user" @change=${this._selectUser.bind(this)}>
+            ${this.config.users.map(u => html`<option value="${u.name}" ?selected=${u.name===this.selectedUser}>${u.name}</option>`)}
+          </select>
+        </div>
+        <table>
+          <thead><tr><th>Getränk</th><th>Anzahl</th><th>Preis</th><th>Summe</th></tr></thead>
+          <tbody>${rows}</tbody>
+          <tfoot><tr><td colspan="3"><b>Gesamt</b></td><td>${total.toFixed(2)}</td></tr></tfoot>
+        </table>
+      </ha-card>
+    `;
+  }
+
+  _selectUser(ev) {
+    this.selectedUser = ev.target.value;
+  }
+
+  static styles = css`
+    ha-card {
+      padding: 16px;
+    }
+    .user-select {
+      margin-bottom: 8px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      padding: 4px;
+      border-bottom: 1px solid var(--divider-color);
+    }
+    tfoot td {
+      font-weight: bold;
+    }
+  `;
+}
+
+customElements.define('drink-counter-card', DrinkCounterCard);
+


### PR DESCRIPTION
## Summary
- add a drink-counter-card custom element
- document how to use it in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687cf118f204832eb96a40f0c94fdcc8