### PR TITLE
Add button for incrementing drinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ha-drink-counter-lovelace
 
-A simple Lovelace card for showing drink counts per user. Select a name and the card displays how many drinks of each type that user has consumed and the amount owed. The card can automatically read all users and drink prices from the **Drink Counter** integration.
+A simple Lovelace card for showing and updating drink counts per user. Select a name and the card displays how many drinks of each type that user has consumed and the amount owed. Each drink row provides an **Add** button to increment the counter. The card can automatically read all users and drink prices from the **Drink Counter** integration.
 
 ## Installation
 

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -1,4 +1,4 @@
-// Drink Counter Card v1.0.0
+// Drink Counter Card v1.1.0
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
 
 class DrinkCounterCard extends LitElement {
@@ -34,7 +34,13 @@ class DrinkCounterCard extends LitElement {
       const price = Number(prices[drink] || 0);
       const cost = count * price;
       total += cost;
-      return html`<tr><td>${drink}</td><td>${count}</td><td>${price}</td><td>${cost.toFixed(2)}</td></tr>`;
+      return html`<tr>
+        <td>${drink}</td>
+        <td>${count}</td>
+        <td>${price}</td>
+        <td>${cost.toFixed(2)}</td>
+        <td><button @click=${() => this._addDrink(drink)}>Add</button></td>
+      </tr>`;
     });
 
     return html`
@@ -46,9 +52,9 @@ class DrinkCounterCard extends LitElement {
           </select>
         </div>
         <table>
-          <thead><tr><th>Getränk</th><th>Anzahl</th><th>Preis</th><th>Summe</th></tr></thead>
+          <thead><tr><th>Getränk</th><th>Anzahl</th><th>Preis</th><th>Summe</th><th></th></tr></thead>
           <tbody>${rows}</tbody>
-          <tfoot><tr><td colspan="3"><b>Gesamt</b></td><td>${total.toFixed(2)}</td></tr></tfoot>
+          <tfoot><tr><td colspan="4"><b>Gesamt</b></td><td>${total.toFixed(2)}</td></tr></tfoot>
         </table>
       </ha-card>
     `;
@@ -56,6 +62,13 @@ class DrinkCounterCard extends LitElement {
 
   _selectUser(ev) {
     this.selectedUser = ev.target.value;
+  }
+
+  _addDrink(drink) {
+    this.hass.callService('drink_counter', 'add_drink', {
+      user: this.selectedUser,
+      drink: drink,
+    });
   }
 
   updated(changedProps) {
@@ -120,6 +133,9 @@ class DrinkCounterCard extends LitElement {
     th, td {
       padding: 4px;
       border-bottom: 1px solid var(--divider-color);
+    }
+    button {
+      padding: 4px;
     }
     tfoot td {
       font-weight: bold;

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": true,
   "filename": "drink-counter-card.js",
   "render_readme": true,
-  "version": "1.0.0"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
## Summary
- add an `Add` button for each drink row
- expose `_addDrink` to call `drink_counter.add_drink`
- bump card version to 1.1.0 and update HACS metadata
- mention add functionality in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cf6618f98832e8102bf7aa30c434c