### PR TITLE
Improve add button refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ha-drink-counter-lovelace
 
-A simple Lovelace card for showing and updating drink counts per user. Select a name and the card displays how many drinks of each type that user has consumed and the amount owed. Each drink row provides an **Add** button on the left to increment the counter. The card can automatically read all users and drink prices from the **Drink Counter** integration.
+A simple Lovelace card for showing and updating drink counts per user. Select a name and the card displays how many drinks of each type that user has consumed and the amount owed. Each drink row provides an **Add** button on the left to increment the counter. The table refreshes automatically after adding a drink. The card can automatically read all users and drink prices from the **Drink Counter** integration.
 
 ## Installation
 

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -69,6 +69,15 @@ class DrinkCounterCard extends LitElement {
       user: this.selectedUser,
       drink: drink,
     });
+
+    const users = this.config.users || this._autoUsers || [];
+    const user = users.find(u => (u.slug || u.name) === this.selectedUser);
+    const entity = user?.drinks?.[drink];
+    if (entity) {
+      this.hass.callService('homeassistant', 'update_entity', {
+        entity_id: entity,
+      });
+    }
   }
 
   updated(changedProps) {


### PR DESCRIPTION
## Summary
- auto-refresh drink entity after using the **Add** button
- clarify automatic refresh in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687cf9f16100832e8e7e68c58c5129d1