### PR TITLE
Fix drink name capitalization

### DIFF
--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -34,9 +34,10 @@ class DrinkCounterCard extends LitElement {
       const price = Number(prices[drink] || 0);
       const cost = count * price;
       total += cost;
+      const displayDrink = drink.charAt(0).toUpperCase() + drink.slice(1);
       return html`<tr>
         <td><button @click=${() => this._addDrink(drink)}>Add</button></td>
-        <td>${drink}</td>
+        <td>${displayDrink}</td>
         <td>${count}</td>
         <td>${price}</td>
         <td>${cost.toFixed(2)}</td>


### PR DESCRIPTION
## Summary
- capitalize drink names when listing drinks in the card

## Testing
- `node --check drink-counter-card.js`


------
https://chatgpt.com/codex/tasks/task_e_687cfc38e10c832e93a76fcf07b34a8a