### PR TITLE
Fix service call to send display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ type: custom:drink-counter-card
 ```
 
 The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required.
+The selected user's **display name** is sent to the `drink_counter.add_drink` service, so capitalization is preserved.
 

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -13,7 +13,8 @@ class DrinkCounterCard extends LitElement {
   setConfig(config) {
     this.config = config;
     if (config.users && Array.isArray(config.users)) {
-      this.selectedUser = config.users[0]?.slug || config.users[0]?.name;
+      // Prefer the configured name to preserve capitalization
+      this.selectedUser = config.users[0]?.name || config.users[0]?.slug;
     }
   }
 
@@ -23,9 +24,10 @@ class DrinkCounterCard extends LitElement {
     if (!this.hass || !this.config) return html``;
     const users = this.config.users || this._autoUsers || [];
     if (!this.selectedUser && users.length > 0) {
-      this.selectedUser = users[0].slug || users[0].name;
+      // Default to the display name if available
+      this.selectedUser = users[0].name || users[0].slug;
     }
-    const user = users.find(u => (u.slug || u.name) === this.selectedUser);
+    const user = users.find(u => (u.name || u.slug) === this.selectedUser);
     if (!user) return html`<ha-card>Unknown user</ha-card>`;
     const prices = this.config.prices || this._autoPrices || {};
     let total = 0;
@@ -49,7 +51,7 @@ class DrinkCounterCard extends LitElement {
         <div class="user-select">
           <label for="user">Name:</label>
           <select id="user" @change=${this._selectUser.bind(this)}>
-            ${users.map(u => html`<option value="${u.slug || u.name}" ?selected=${(u.slug || u.name)===this.selectedUser}>${u.name}</option>`)}
+            ${users.map(u => html`<option value="${u.name || u.slug}" ?selected=${(u.name || u.slug)===this.selectedUser}>${u.name}</option>`)}
           </select>
         </div>
           <table>
@@ -72,7 +74,7 @@ class DrinkCounterCard extends LitElement {
     });
 
     const users = this.config.users || this._autoUsers || [];
-    const user = users.find(u => (u.slug || u.name) === this.selectedUser);
+    const user = users.find(u => (u.name || u.slug) === this.selectedUser);
     const entity = user?.drinks?.[drink];
     if (entity) {
       this.hass.callService('homeassistant', 'update_entity', {


### PR DESCRIPTION
## Summary
- use the user's display name when calling the `drink_counter.add_drink` service
- document that the display name (with capitalization) is sent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cfbca15fc832e8f2c3f98a783ae36