### PR TITLE
Add delay to Add button

### DIFF
--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -1,4 +1,4 @@
-// Drink Counter Card v1.1.2
+// Drink Counter Card v1.1.3
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
 
 class DrinkCounterCard extends LitElement {
@@ -8,10 +8,12 @@ class DrinkCounterCard extends LitElement {
     selectedUser: { state: true },
     _autoUsers: { state: true },
     _autoPrices: { state: true },
+    _disabled: { state: true },
   };
 
   setConfig(config) {
     this.config = config;
+    this._disabled = false;
     if (config.users && Array.isArray(config.users)) {
       // Prefer the configured name to preserve capitalization
       this.selectedUser = config.users[0]?.name || config.users[0]?.slug;
@@ -40,7 +42,7 @@ class DrinkCounterCard extends LitElement {
       total += cost;
       const displayDrink = drink.charAt(0).toUpperCase() + drink.slice(1);
       return html`<tr>
-        <td><button @click=${() => this._addDrink(drink)}>Add</button></td>
+        <td><button @click=${() => this._addDrink(drink)} ?disabled=${this._disabled}>Add</button></td>
         <td>${displayDrink}</td>
         <td>${count}</td>
         <td>${price}</td>
@@ -70,6 +72,15 @@ class DrinkCounterCard extends LitElement {
   }
 
   _addDrink(drink) {
+    if (this._disabled) {
+      return;
+    }
+    this._disabled = true;
+    this.requestUpdate();
+    setTimeout(() => {
+      this._disabled = false;
+      this.requestUpdate();
+    }, 1000);
     const displayDrink = drink.charAt(0).toUpperCase() + drink.slice(1);
     this.hass.callService('drink_counter', 'add_drink', {
       user: this.selectedUser,


### PR DESCRIPTION
## Summary
- introduce `_disabled` state to manage click delay
- disable all `Add` buttons for one second after a click
- bump card version comment

## Testing
- `node -c drink-counter-card.js`

------
https://chatgpt.com/codex/tasks/task_e_687d00c2fd84832eb42927dbf80dcee8