### PR TITLE
Left align user dropdown

### DIFF
--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -192,9 +192,9 @@ class DrinkCounterCard extends LitElement {
       margin-bottom: 8px;
     }
     .user-select {
-      text-align: center;
+      text-align: left;
       display: flex;
-      justify-content: center;
+      justify-content: flex-start;
       align-items: center;
       gap: 8px;
     }


### PR DESCRIPTION
## Summary
- left align the name dropdown so the remove drink button sits on the right

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d05bc262c832e849bccd302dbddb4