### PR TITLE
Improve drink dropdown for touch devices

### DIFF
--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -210,10 +210,11 @@ class DrinkCounterCard extends LitElement {
       align-items: center;
       gap: 8px;
     }
-    .user-select select {
-      padding: 8px;
-      min-width: 120px;
-      font-size: 1rem;
+    .user-select select,
+    .remove-container select {
+      padding: 12px;
+      min-width: 140px;
+      font-size: 1.2rem;
     }
     table {
       width: 100%;


### PR DESCRIPTION
## Summary
- enlarge the dropdown menus to be easier to tap on touchscreens

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687d08995630832e8e3b939b4900122b