### PR TITLE
Align dropdown menu styles

### DIFF
--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -216,11 +216,6 @@ class DrinkCounterCard extends LitElement {
       min-width: 140px;
       font-size: 1.2rem;
     }
-    .remove-container select {
-      padding: 8px;
-      min-width: 120px;
-      font-size: 1rem;
-    }
     table {
       width: 100%;
       border-collapse: collapse;


### PR DESCRIPTION
## Summary
- remove extra style rules so the user selector and remove drink menu share the same padding, width and font size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d0a970140832ebcbcb3f9aa537ceb