### PR TITLE
Improve dropdown sizing

### DIFF
--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -212,10 +212,10 @@ class DrinkCounterCard extends LitElement {
     }
     .user-select select,
     .remove-container select {
-      padding: 12px;
-      min-width: 140px;
-      font-size: 1.2rem;
-      height: 48px;
+      padding: 4px 8px;
+      min-width: 120px;
+      font-size: 1rem;
+      height: 36px;
       box-sizing: border-box;
     }
     table {


### PR DESCRIPTION
## Summary
- shrink dropdown dimensions so buttons aren't so large

## Testing
- `node --check drink-counter-card.js`


------
https://chatgpt.com/codex/tasks/task_e_687d0c8f766c832ea4ec2f448ae5d249