### PR TITLE
Add Euro symbol for prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ha-drink-counter-lovelace
 
-A simple Lovelace card for showing and updating drink counts per user. Select a name and the card displays how many drinks of each type that user has consumed and the amount owed. Each drink row provides an **+1** button on the left to increment the counter. The table refreshes automatically after adding a drink. The card can automatically read all users and drink prices from the **Drink Counter** integration.
+A simple Lovelace card for showing and updating drink counts per user. Select a name and the card displays how many drinks of each type that user has consumed and the amount owed. Prices are shown with the **€** symbol. Each drink row provides an **+1** button on the left to increment the counter. The table refreshes automatically after adding a drink. The card can automatically read all users and drink prices from the **Drink Counter** integration.
 
 ## Installation
 

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -41,10 +41,10 @@ class DrinkCounterCard extends LitElement {
       .map(([drink, entity]) => {
         const count = Number(this.hass.states[entity]?.state || 0);
         const price = Number(prices[drink] || 0);
-        const priceStr = price.toFixed(2);
+        const priceStr = price.toFixed(2) + ' €';
         const cost = count * price;
         total += cost;
-        const costStr = cost.toFixed(2);
+        const costStr = cost.toFixed(2) + ' €';
         const displayDrink = drink.charAt(0).toUpperCase() + drink.slice(1);
         return html`<tr>
           <td><button @click=${() => this._addDrink(drink)} ?disabled=${this._disabled}>+1</button></td>
@@ -60,7 +60,7 @@ class DrinkCounterCard extends LitElement {
       this.selectedRemoveDrink = drinks[0];
     }
 
-    const totalStr = total.toFixed(2);
+    const totalStr = total.toFixed(2) + ' €';
     return html`
       <ha-card>
         <div class="controls">


### PR DESCRIPTION
## Summary
- display prices in Euro with a "€" suffix
- document that prices show the Euro symbol

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d169b7900832e855449ae4f979719