### PR TITLE
Implement free amount deduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,5 @@ data:
   drink: Wasser
 ```
 
+If `sensor.preisliste_free_amount` exists, its value is deducted from every user's total. The table displays this free amount and shows the final **Zu zahlen** sum.
+

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": true,
   "filename": "drink-counter-card.js",
   "render_readme": true,
-  "version": "1.1.1"
+  "version": "1.2.0"
 }


### PR DESCRIPTION
## Summary
- show and subtract a free amount from the total
- document the free amount sensor
- bump version to 1.2.0

## Testing
- `node --check drink-counter-card.js`

------
https://chatgpt.com/codex/tasks/task_e_687d1d7cb48c832ead032c95da038e15