### PR TITLE
Enhance card to read amount_due sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,5 @@ data:
 ```
 
 If `sensor.preisliste_free_amount` exists, its value is deducted from every user's total. The table displays this free amount and shows the final **Zu zahlen** sum.
+When sensors named `sensor.<name>_amount_due` are present, their values are used directly for the **Zu zahlen** row instead of calculating it from the drink counts.
 

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -64,7 +64,14 @@ class DrinkCounterCard extends LitElement {
 
     const totalStr = total.toFixed(2) + ' €';
     const freeAmountStr = freeAmount.toFixed(2) + ' €';
-    const due = Math.max(total - freeAmount, 0);
+    let due;
+    if (user.amount_due_entity) {
+      const dueState = this.hass.states[user.amount_due_entity];
+      const val = parseFloat(dueState?.state);
+      due = isNaN(val) ? Math.max(total - freeAmount, 0) : val;
+    } else {
+      due = Math.max(total - freeAmount, 0);
+    }
     const dueStr = due.toFixed(2) + ' €';
     return html`
       <ha-card>
@@ -187,7 +194,7 @@ class DrinkCounterCard extends LitElement {
             drinks[drink] = e2;
           }
         }
-        users.push({ name: name || slug, slug, drinks });
+        users.push({ name: name || slug, slug, drinks, amount_due_entity: entity });
       }
     }
     return users;


### PR DESCRIPTION
## Summary
- show amount due from `sensor.<name>_amount_due` if available
- document new behaviour in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d1f409d64832eb7b0d18ebcf7551f