### PR TITLE
Hide due rows when free amount is zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,5 @@ data:
 
 If `sensor.preisliste_free_amount` exists, its value is deducted from every user's total. The table displays this free amount and shows the final **Zu zahlen** sum.
 
+If the free amount equals **0 €**, the card hides the **Freibetrag** and **Zu zahlen** rows and only shows the **Gesamt** line.
+

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -87,8 +87,10 @@ class DrinkCounterCard extends LitElement {
           <tbody>${rows}</tbody>
           <tfoot>
             <tr><td colspan="4"><b>Gesamt</b></td><td>${totalStr}</td></tr>
-            ${freeAmount > 0 ? html`<tr><td colspan="4"><b>Freibetrag</b></td><td>- ${freeAmountStr}</td></tr>` : ''}
-            <tr><td colspan="4"><b>Zu zahlen</b></td><td>${dueStr}</td></tr>
+            ${freeAmount > 0 ? html`
+              <tr><td colspan="4"><b>Freibetrag</b></td><td>- ${freeAmountStr}</td></tr>
+              <tr><td colspan="4"><b>Zu zahlen</b></td><td>${dueStr}</td></tr>
+            ` : ''}
           </tfoot>
         </table>
       </ha-card>


### PR DESCRIPTION
## Summary
- hide the "Freibetrag" and "Zu zahlen" rows when free amount is 0
- document this behaviour in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d20163c0c832ebfe29f745fe0a100