### PR TITLE
Fix minus button size

### DIFF
--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -249,6 +249,10 @@ class DrinkCounterCard extends LitElement {
       height: 32px;
       box-sizing: border-box;
     }
+    .remove-container button {
+      height: 32px;
+      width: 32px;
+    }
     table {
       width: 100%;
       border-collapse: collapse;


### PR DESCRIPTION
## Summary
- enlarge the remove-drink button so it matches the +1 buttons

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687d2761c1ec832e83a4f6545dbdc78d