### PR TITLE
Set +1 button size to 32x32

### DIFF
--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -49,7 +49,7 @@ class DrinkCounterCard extends LitElement {
         const costStr = cost.toFixed(2) + ' €';
         const displayDrink = drink.charAt(0).toUpperCase() + drink.slice(1);
         return html`<tr>
-          <td><button @click=${() => this._addDrink(drink)} ?disabled=${this._disabled}>+1</button></td>
+          <td><button class="add-button" @click=${() => this._addDrink(drink)} ?disabled=${this._disabled}>+1</button></td>
           <td>${displayDrink}</td>
           <td>${count}</td>
           <td>${priceStr}</td>
@@ -250,6 +250,10 @@ class DrinkCounterCard extends LitElement {
       box-sizing: border-box;
     }
     .remove-container button {
+      height: 32px;
+      width: 32px;
+    }
+    .add-button {
       height: 32px;
       width: 32px;
     }


### PR DESCRIPTION
## Summary
- add `add-button` class to the plus button
- style the new class so the +1 button is 32×32

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d29f9b7cc832ebc8fbcc08a99b4b6