### PR TITLE
Fix layout on small screens

### DIFF
--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -242,6 +242,8 @@ class DrinkCounterCard extends LitElement {
       display: flex;
       justify-content: space-between;
       align-items: center;
+      flex-wrap: wrap;
+      gap: 8px;
       margin-bottom: 8px;
     }
     .user-select {
@@ -258,6 +260,11 @@ class DrinkCounterCard extends LitElement {
       font-size: 1rem;
       height: 32px;
       box-sizing: border-box;
+    }
+    .remove-container {
+      display: flex;
+      align-items: center;
+      gap: 8px;
     }
     .remove-container button {
       height: 32px;


### PR DESCRIPTION
## Summary
- wrap the menu container so user dropdown and remove button stack on narrow displays
- display the remove drink container as flex to keep select and button aligned

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e6f7d0b60832e8b41a1c9f48cd459