### PR TITLE
Enable adding card from Lovelace UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,15 @@ A simple Lovelace card for showing and updating drink counts per user. Select a 
 1. Copy `drink-counter-card.js` to your Home Assistant `www` directory.
 2. Add the following to your Lovelace resources:
    ```yaml
-   - url: /local/drink-counter-card.js
-     type: module
-   ```
+  - url: /local/drink-counter-card.js
+    type: module
+  ```
+
+### Add to Lovelace
+
+After the resource is available, open the Lovelace dashboard, click **Add Card**
+and select **Drink Counter Card** from the list. The built-in editor lets you
+adjust the lock time without writing YAML.
 
 ## Example
 

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -1,6 +1,14 @@
 // Drink Counter Card v1.3.1
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
 
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: 'drink-counter-card',
+  name: 'Drink Counter Card',
+  preview: true,
+  description: 'Displays drink counts per user with quick add/remove buttons.',
+});
+
 class DrinkCounterCard extends LitElement {
   static properties = {
     hass: {},


### PR DESCRIPTION
## Summary
- register card with `window.customCards` so Lovelace can list it when adding a card
- document that the card can now be added through the UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e719992bc832eac165515c6142bb2