### PR TITLE
Add max width normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ If the free amount equals **0 €**, the card hides the **Freibetrag** and **Z
 
 ## UI configuration
 
-The card can now be configured directly in the Lovelace UI. It offers a single option:
+The card can now be configured directly in the Lovelace UI. It offers the following options:
 
 * **Sperrzeit (ms)** – How long the buttons stay disabled after pressing **+1** or **-1**. The default is `1000` milliseconds.
+* **Maximale Breite** – Optional width limit for the card. If you enter just a number, `px` is assumed. Useful when using panel views to prevent the layout from stretching too wide.
 

--- a/drink-counter-card-editor.js
+++ b/drink-counter-card-editor.js
@@ -16,7 +16,7 @@ class DrinkCounterCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { lock_ms: 1000, ...config };
+    this._config = { lock_ms: 1000, max_width: '', ...config };
   }
 
   render() {
@@ -27,15 +27,32 @@ class DrinkCounterCardEditor extends LitElement {
         <input
           type="number"
           .value=${this._config.lock_ms}
-          @input=${this._valueChanged}
+          @input=${this._lockChanged}
+        />
+      </div>
+      <div class="form">
+        <label>Maximale Breite</label>
+        <input
+          type="text"
+          .value=${this._config.max_width ?? ''}
+          @input=${this._widthChanged}
         />
       </div>
     `;
   }
 
-  _valueChanged(ev) {
+  _lockChanged(ev) {
     const value = Number(ev.target.value);
     this._config = { ...this._config, lock_ms: isNaN(value) ? 1000 : value };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _widthChanged(ev) {
+    let value = ev.target.value.trim();
+    if (/^\d+$/.test(value)) {
+      value = `${value}px`;
+    }
+    this._config = { ...this._config, max_width: value };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": true,
   "filename": "drink-counter-card.js",
   "render_readme": true,
-  "version": "1.3.1"
+  "version": "1.3.4"
 }


### PR DESCRIPTION
## Summary
- automatically append `px` if `max_width` is a number
- mention default pixel units in README
- bump component version to 1.3.4

## Testing
- `node --check drink-counter-card.js`
- `node --check drink-counter-card-editor.js`


------
https://chatgpt.com/codex/tasks/task_e_687e708e0ad8832e9ac6ea9d2468ab9c